### PR TITLE
Update templates, add CI/CD actions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,49 @@
+--
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+---
+
+**Describe the bug**
+
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+
+Steps to reproduce the behavior:
+
+1. Go to '...'
+
+2. Click on '....'
+
+3. Scroll down to '....'
+
+4. See error
+
+**Expected behavior**
+
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+
+If applicable, add screenshots to help explain your problem.
+
+
+**Desktop (please complete the following information):**
+
+- OS: [e.g. iOS]
+- Browser [e.g. chrome, safari]
+- Version [e.g. 22]
+
+**Smartphone (please complete the following information):**
+
+- Device: [e.g. iPhone6]
+- OS: [e.g. iOS8.1]
+- Browser [e.g. stock browser, safari]
+- Version [e.g. 22]
+
+**Additional context**
+
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,26 @@
+
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+---
+
+
+**Is your feature request related to a problem? Please describe.**
+
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+
+Add any other context or screenshots about the feature request here.
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+### Summary
+
+<!-- Summarize the change and indicate whether this will be a major/minor/patch change -->
+
+### Checklist
+
+- [ ] Added a changelog entry
+
+### Authors
+
+> List GitHub usernames for everyone who contributed to this pull request.
+
+-
+
+### Reviewers
+
+@braintree/team-sdk-js
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,14 @@
-name: "Unit Tests"
+name: "CI"
 
-on: [push]
+on:
+  push:
+    branches:
+      - 'main'
+  workflow_dispatch:
+  workflow_call:
+  pull_request:
+    branches:
+        - '*'
 
 jobs:
   build:
@@ -10,8 +18,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
-          node-version: "18.x"
+          node-version-file: .nvmrc
       - run: npm install
       - run: npm test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,51 @@
+# This workflow will run tests using node, bump the npm version, deploy to npm, and create a release with notes
+
+name: Publish to npm
+run-name: Deploy ${{ github.repository }} to npmjs by @${{ github.actor }}
+on:
+  workflow_dispatch:
+    inputs:
+      version_type:
+        description: "Version bump type (major, minor, patch)"
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+env:
+  NPM_REGISTRY: https://registry.npmjs.org/
+
+concurrency: # prevent concurrent releases
+  group: npm-publish
+  cancel-in-progress: true
+
+jobs:
+  ci:
+    uses: ./.github/workflows/ci.yml
+  bump-version:
+    needs: ci
+    uses: ./.github/workflows/version-bump.yml
+    with:
+      version_type: ${{ inputs.version_type }}
+  publish-npm:
+    needs: bump-version
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          registry-url: ${{ env.NPM_REGISTRY }}
+      - run: git pull # Pull down changes from previous step
+      - run: npm ci
+      - run: npm publish --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.BRAINTREE_NPM_ACCESS_TOKEN }}
+  publish-release:
+    needs: publish-npm
+    uses: ./.github/workflows/release-notes.yml
+

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -1,0 +1,44 @@
+# This workflow will create a release for the most recent deploy
+
+name: Create release
+run-name: Running github release
+on:
+  workflow_dispatch:
+  workflow_call:
+
+jobs:
+  create_release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+
+      - run: |
+          git checkout main
+          git pull
+
+      - name: Get version
+        run: echo "latest_version=$(npm pkg get version --workspaces=false | tr -d \")" >> $GITHUB_ENV
+
+      - name: Get details
+        run: |
+          {
+            echo 'release_details<<EOF'
+            awk '/^## / { if (p) exit; p=1 } p' CHANGELOG.md | sed '1d'
+            echo EOF
+          } >> $GITHUB_ENV
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+        with:
+          tag_name: ${{ env.latest_version }}
+          release_name: v${{ env.latest_version }}
+          body: "${{ env.release_details }}"
+          draft: false
+          prerelease: false
+

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -1,0 +1,66 @@
+# This workflow will bump the version
+
+name: Bump version and update changelog
+
+on:
+  workflow_call:
+    inputs:
+      version_type:
+        description: "Version bump type (major, minor, patch)"
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      version_type:
+        description: "Version bump type (major, minor, patch)"
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+jobs:
+  version_bump:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+
+      - name: Configure Github Credentials
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+
+      - name: Check Changelog
+        run: |
+          if ! grep -i -q "## UNRELEASED" CHANGELOG.md; then
+            echo "Error: 'UNRELEASED' not found in CHANGELOG.md. Please ensure the changelog is correctly formatted."
+            exit 1
+          fi
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+
+      - name: Bump npm version
+        run: |
+          new_version=$(npm version ${{ inputs.version_type }})
+          echo "new_version=$(echo $new_version | sed 's/v//')" >> $GITHUB_ENV
+
+      - name: Update changelog
+        run: |
+          today=$(date +'%Y-%m-%d')
+          sed -i "s/## unreleased/## ${{ env.new_version }} (${today})/i" CHANGELOG.md
+
+      - name: Commit and push changes
+        run: |
+          git tag -m  ${{ env.new_version }} ${{ env.new_version }}
+          git add --all
+          git commit -m "v${{ env.new_version }}"
+          git push
+


### PR DESCRIPTION


Added GitHub actions to support build and deploy.

`ci.yml`

- Change name, config when workflow runs, update setup-node versions

`publish.yml`

- Adding workflow to publish to gh-pages

`release-notes.yaml`

- generate release notes

`version-bump.yml`

- workflow to update package version

Also added PR templates.
Added issue templates - bug report and feature request.
