### PR TITLE
Add token to PR merge command

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -90,6 +90,8 @@ jobs:
           pr_number=$(echo ${{ env.pr_url }} | awk -F/ '{print $NF}')
           gh pr merge $pr_number --merge --delete-branch
           echo "####  Merged PR" >> $GITHUB_STEP_SUMMARY
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Tag
         run: |
           git tag -m ${{ env.new_version }} ${{ env.new_version }}


### PR DESCRIPTION
### Summary

Add GitHub token to GH PR merge command.  Previous execution of version bump workflow failed to merge PR due to missing token. 

### Checklist

- [ ] Added a changelog entry

### Authors

> List GitHub usernames for everyone who contributed to this pull request.

- @ibooker 

### Reviewers

@braintree/team-sdk-js

