### PR TITLE
Change master reference to main

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -80,7 +80,7 @@ jobs:
 
       - name: Create PR
         run: |
-          pr_url=$(gh pr create --title "Release v${{ env.new_version }}" --body "Updated changelog for release v${{ env.new_version }}" --base master --head release/v${{ env.new_version }})
+          pr_url=$(gh pr create --title "Release v${{ env.new_version }}" --body "Updated changelog for release v${{ env.new_version }}" --base main --head release/v${{ env.new_version }})
           echo "pr_url=$pr_url" >> $GITHUB_ENV
           echo "#### Created PR ($pr_url) for release" >> $GITHUB_STEP_SUMMARY
         env:


### PR DESCRIPTION
### Summary

There's a reference to the `master` branch that's a result of initial testing in a repo using a `master` instead of `main` branch.

### Checklist

- [ ] Added a changelog entry

### Authors

> List GitHub usernames for everyone who contributed to this pull request.

- @ibooker

### Reviewers

@braintree/team-sdk-js

