### PR TITLE
chore: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,4 +14,4 @@ permissions:
 
 jobs:
   ci:
-    uses: braintree/web-sdk-github-actions/.github/workflows/ci.yml@17a3922575160e8e3ffdb7ecc76c6a3dbfd6a50a
+    uses: braintree/web-sdk-github-actions/.github/workflows/ci.yml@7a0129438dde00a728cc851ce2cab9820bb264ed  # main

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,8 +35,8 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version-file: .nvmrc
           registry-url: ${{ env.NPM_REGISTRY }}

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -10,8 +10,8 @@ jobs:
   create_release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version-file: .nvmrc
 
@@ -32,7 +32,7 @@ jobs:
 
       - name: Create Release
         id: create_release
-        uses: actions/create-release@v1
+        uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e  # v1 (deprecated; migrate off)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         with:

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Configure Github Credentials
         run: |
@@ -44,7 +44,7 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version-file: .nvmrc
 


### PR DESCRIPTION
# Summary of changes

- Pins GitHub Actions and reusable workflow references to full-length commit SHAs, per GitHub's secure-use guidance for third-party actions. SHA-pinned refs carry a trailing comment with the original tag/branch for readability.

## Checklist

- [ ] Added a changelog entry
- [ ] Relevant test coverage
- [ ] Tested and confirmed flows affected by this change are functioning as expected

## Authors

> List GitHub usernames for everyone who contributed to this pull request.

### Reviewers

@braintree/team-sdk-js